### PR TITLE
Fixed typo in en_us.json

### DIFF
--- a/common/src/main/resources/assets/meadow/lang/en_us.json
+++ b/common/src/main/resources/assets/meadow/lang/en_us.json
@@ -154,7 +154,7 @@
   "block.meadow.window_shutter_2": "Painted Window Shutter (Grapevine)",
   "block.meadow.window_shutter_3": "Painted Window Shutter (Fir)",
   "block.meadow.woodcutter": "Woodcutter",
-  "block.meadow.woodcutter.tooltip":"Save ressources by chopping Logs.",
+  "block.meadow.woodcutter.tooltip":"Save resources by chopping Logs.",
   "block.meadow.wooden_cauldron": "Wooden Cauldron",
   "block.meadow.wooden_flower_pot": "Wooden Flower Pot",
   "block.meadow.woodencauldron.tooltip": "Same functions as a Cauldron",


### PR DESCRIPTION
Removed extra "s" in "resources" for `block.meadow.woodcutter.tooltip`