### PR TITLE
Alpine ore additional tags & fixed loot tables

### DIFF
--- a/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_copper_ore.json
+++ b/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_copper_ore.json
@@ -1,49 +1,59 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "bonus_rolls": 0,
-      "entries": [
-        {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:item",
-              "conditions": [
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
-                        }
-                      }
-                    ]
-                  }
-                }
-              ],
-              "name": "meadow:alpine_coal_ore"
-            },
-            {
-              "type": "minecraft:item",
-              "functions": [
-                {
-                  "enchantment": "minecraft:fortune",
-                  "formula": "minecraft:ore_drops",
-                  "function": "minecraft:apply_bonus"
-                },
-                {
-                  "function": "minecraft:explosion_decay"
-                }
-              ],
-              "name": "minecraft:raw_copper"
-            }
-          ]
-        }
-      ],
-      "rolls": 1
-    }
-  ]
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"name": "main",
+			"rolls": 1.0,
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:alternatives",
+					"children": [
+						{
+							"type": "minecraft:item",
+							"conditions": [
+								{
+									"condition": "minecraft:match_tool",
+									"predicate": {
+										"enchantments": [
+											{
+												"enchantment": "minecraft:silk_touch",
+												"levels": {
+													"min": 1
+												}
+											}
+										]
+									}
+								}
+							],
+							"name": "meadow:alpine_copper_ore"
+						},
+						{
+							"type": "minecraft:item",
+							"functions": [
+								{
+									"function": "minecraft:set_count",
+									"count": {
+										"type": "minecraft:uniform",
+										"min": 2.0,
+										"max": 5.0
+									},
+									"add": false
+								},
+								{
+									"function": "minecraft:apply_bonus",
+									"enchantment": "minecraft:fortune",
+									"formula": "minecraft:ore_drops"
+								},
+								{
+									"function": "minecraft:explosion_decay"
+								}
+							],
+							"name": "minecraft:raw_copper"
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_diamond_ore.json
+++ b/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_diamond_ore.json
@@ -1,49 +1,50 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "bonus_rolls": 0,
-      "entries": [
-        {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:item",
-              "conditions": [
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
-                        }
-                      }
-                    ]
-                  }
-                }
-              ],
-              "name": "meadow:alpine_coal_ore"
-            },
-            {
-              "type": "minecraft:item",
-              "functions": [
-                {
-                  "enchantment": "minecraft:fortune",
-                  "formula": "minecraft:ore_drops",
-                  "function": "minecraft:apply_bonus"
-                },
-                {
-                  "function": "minecraft:explosion_decay"
-                }
-              ],
-              "name": "minecraft:diamond"
-            }
-          ]
-        }
-      ],
-      "rolls": 1
-    }
-  ]
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"name": "main",
+			"rolls": 1.0,
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:alternatives",
+					"children": [
+						{
+							"type": "minecraft:item",
+							"conditions": [
+								{
+									"condition": "minecraft:match_tool",
+									"predicate": {
+										"enchantments": [
+											{
+												"enchantment": "minecraft:silk_touch",
+												"levels": {
+													"min": 1
+												}
+											}
+										]
+									}
+								}
+							],
+							"name": "meadow:alpine_diamond_ore"
+						},
+						{
+							"type": "minecraft:item",
+							"functions": [
+								{
+									"function": "minecraft:apply_bonus",
+									"enchantment": "minecraft:fortune",
+									"formula": "minecraft:ore_drops"
+								},
+								{
+									"function": "minecraft:explosion_decay"
+								}
+							],
+							"name": "minecraft:diamond"
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_lapis_ore.json
+++ b/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_lapis_ore.json
@@ -1,49 +1,60 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "bonus_rolls": 0,
-      "entries": [
-        {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:item",
-              "conditions": [
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
-                        }
-                      }
-                    ]
-                  }
-                }
-              ],
-              "name": "meadow:alpine_lapis_ore"
-            },
-            {
-              "type": "minecraft:item",
-              "functions": [
-                {
-                  "enchantment": "minecraft:fortune",
-                  "formula": "minecraft:ore_drops",
-                  "function": "minecraft:apply_bonus"
-                },
-                {
-                  "function": "minecraft:explosion_decay"
-                }
-              ],
-              "name": "minecraft:lapis_lazuli"
-            }
-          ]
-        }
-      ],
-      "rolls": 1
-    }
-  ]
+	"type": "minecraft:block",
+	"random_sequence": "minecraft:blocks/deepslate_lapis_ore",
+	"pools": [
+		{
+			"name": "main",
+			"rolls": 1.0,
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:alternatives",
+					"children": [
+						{
+							"type": "minecraft:item",
+							"conditions": [
+								{
+									"condition": "minecraft:match_tool",
+									"predicate": {
+										"enchantments": [
+											{
+												"enchantment": "minecraft:silk_touch",
+												"levels": {
+													"min": 1
+												}
+											}
+										]
+									}
+								}
+							],
+							"name": "meadow:alpine_lapis_ore"
+						},
+						{
+							"type": "minecraft:item",
+							"functions": [
+								{
+									"function": "minecraft:set_count",
+									"count": {
+										"type": "minecraft:uniform",
+										"min": 4.0,
+										"max": 9.0
+									},
+									"add": false
+								},
+								{
+									"function": "minecraft:apply_bonus",
+									"enchantment": "minecraft:fortune",
+									"formula": "minecraft:ore_drops"
+								},
+								{
+									"function": "minecraft:explosion_decay"
+								}
+							],
+							"name": "minecraft:lapis_lazuli"
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_redstone_ore.json
+++ b/common/src/main/resources/data/meadow/loot_tables/blocks/alpine_redstone_ore.json
@@ -1,49 +1,62 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "bonus_rolls": 0,
-      "entries": [
+    "type": "minecraft:block",
+    "pools": [
         {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:item",
-              "conditions": [
+            "name": "main",
+            "rolls": 1,
+            "bonus_rolls": 0,
+            "entries": [
                 {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "type": "minecraft:alternatives",
+                    "children": [
+                        {
+                            "type": "minecraft:item",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:match_tool",
+                                    "predicate": {
+                                        "enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "name": "meadow:alpine_redstone_ore"
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": {
+                                        "type": "minecraft:uniform",
+                                        "min": 4,
+                                        "max": 5
+                                    },
+                                    "add": false
+                                },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "minecraft:uniform_bonus_count",
+                                    "parameters": {
+                                        "bonusMultiplier": 1
+                                    }
+                                },
+                                {
+                                    "function": "minecraft:explosion_decay"
+                                }
+                            ],
+                            "name": "minecraft:redstone"
                         }
-                      }
                     ]
-                  }
                 }
-              ],
-              "name": "meadow:alpine_coal_ore"
-            },
-            {
-              "type": "minecraft:item",
-              "functions": [
-                {
-                  "enchantment": "minecraft:fortune",
-                  "formula": "minecraft:ore_drops",
-                  "function": "minecraft:apply_bonus"
-                },
-                {
-                  "function": "minecraft:explosion_decay"
-                }
-              ],
-              "name": "minecraft:redstone"
-            }
-          ]
+            ]
         }
-      ],
-      "rolls": 1
-    }
-  ]
+    ]
 }

--- a/common/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "meadow:alpine_gold_ore",
+    "meadow:alpine_diamond_ore",
+    "meadow:alpine_emerald_ore",
+    "meadow:alpine_redstone_ore"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "meadow:alpine_copper_ore",
+    "meadow:alpine_iron_ore",
+    "meadow:alpine_lapis_ore"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper_large.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper_large.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_copper_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:copper_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_copper_ore"
+          }
+        }
+      ],
+      "size": 20,
+      "discard_chance_on_air_exposure": 0.0
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper_small.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper_small.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_copper_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:copper_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_copper_ore"
+          }
+        }
+      ],
+      "size": 10,
+      "discard_chance_on_air_exposure": 0.0
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_buried.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_buried.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_diamond_ore"
+          }
+        }
+      ],
+      "size": 8,
+      "discard_chance_on_air_exposure": 1.0
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_large.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_large.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_diamond_ore"
+          }
+        }
+      ],
+      "size": 12,
+      "discard_chance_on_air_exposure": 0.7
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_medium.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_medium.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_diamond_ore"
+          }
+        }
+      ],
+      "size": 8,
+      "discard_chance_on_air_exposure": 0.5
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_small.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_diamond_small.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:diamond_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Name": "minecraft:deepslate_diamond_ore"
+          }
+        }
+      ],
+      "size": 4,
+      "discard_chance_on_air_exposure": 0.5
+    },
+    "type": "minecraft:ore"
+  }

--- a/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_redstone.json
+++ b/common/src/main/resources/data/minecraft/worldgen/configured_feature/ore_redstone.json
@@ -1,0 +1,42 @@
+{
+    "config": {
+      "targets": [
+        {
+          "target": {
+            "block": "meadow:limestone",
+            "predicate_type": "minecraft:block_match"
+          },
+          "state": {
+            "Name": "meadow:alpine_redstone_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:stone_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Properties": {
+              "lit": "false"
+            },
+            "Name": "minecraft:redstone_ore"
+          }
+        },
+        {
+          "target": {
+            "tag": "minecraft:deepslate_ore_replaceables",
+            "predicate_type": "minecraft:tag_match"
+          },
+          "state": {
+            "Properties": {
+              "lit": "false"
+            },
+            "Name": "minecraft:deepslate_redstone_ore"
+          }
+        }
+      ],
+      "size": 8,
+      "discard_chance_on_air_exposure": 0.0
+    },
+    "type": "minecraft:ore"
+  }


### PR DESCRIPTION
Some of the loot tables for the alpine ores were messed up, such as `meadow:alpine_diamond_ore` dropping `meadow:alpine_coal_ore` when mined with silk touch or `meadow:alpine_redstone_ore` dropping only one redstone dust when mined, and they were all missing the tool tier block tags.