### PR TITLE
feat(recipes): use tags instead of items for salt and eggs

### DIFF
--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/amethyst_milk.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/amethyst_milk.json
@@ -5,7 +5,7 @@
       "item": "minecraft:amethyst_cluster"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     },
     {
       "tag": "meadow:milk"

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/baked_potato.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/baked_potato.json
@@ -5,7 +5,7 @@
       "item": "minecraft:potato"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 10,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_beef.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_beef.json
@@ -5,7 +5,7 @@
       "item": "minecraft:beef"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 2,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_buffalo_meat.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_buffalo_meat.json
@@ -5,7 +5,7 @@
       "item": "meadow:raw_buffalo_meat"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 10,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_chicken.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_chicken.json
@@ -5,7 +5,7 @@
       "item": "minecraft:chicken"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 5,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_cod.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_cod.json
@@ -5,7 +5,7 @@
       "item": "minecraft:cod"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 12,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_mutton.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_mutton.json
@@ -5,7 +5,7 @@
       "item": "minecraft:mutton"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 5,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_porkchop.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_porkchop.json
@@ -5,7 +5,7 @@
       "item": "minecraft:porkchop"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 5,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_rabbit.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_rabbit.json
@@ -5,7 +5,7 @@
       "item": "minecraft:rabbit"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 10,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_salmon.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/cooked_salmon.json
@@ -5,7 +5,7 @@
       "item": "minecraft:salmon"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     }
   ],
   "fluid_amount": 12,

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/ham_cheese.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/ham_cheese.json
@@ -5,7 +5,7 @@
       "item": "meadow:raw_buffalo_meat"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     },
     {
       "tag": "meadow:cheese"

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/rennet.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/rennet.json
@@ -2,10 +2,10 @@
   "type": "meadow:cooking",
   "ingredients": [
     {
-      "item": "minecraft:egg"
+      "tag": "meadow:egg"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     },
     {
       "item": "minecraft:glass_bottle"

--- a/common/src/main/resources/data/meadow/recipes/cooking_pot/roasted_ham.json
+++ b/common/src/main/resources/data/meadow/recipes/cooking_pot/roasted_ham.json
@@ -11,7 +11,7 @@
       "item": "meadow:raw_buffalo_meat"
     },
     {
-      "item": "meadow:alpine_salt"
+      "tag": "meadow:salt"
     },
     {
       "item": "minecraft:potato"


### PR DESCRIPTION
Changes meadow:cooking recipes to use common tags for eggs and salt for more general compatibility