### PR TITLE
Fix recipes

### DIFF
--- a/common/src/main/java/net/satisfy/meadow/core/recipes/CookingCauldronRecipe.java
+++ b/common/src/main/java/net/satisfy/meadow/core/recipes/CookingCauldronRecipe.java
@@ -33,7 +33,7 @@ public class CookingCauldronRecipe implements Recipe<Container> {
 
     @Override
     public boolean matches(Container inventory, Level world) {
-        return GeneralUtil.matchesRecipe(inventory, inputs, 1, 6);
+        return GeneralUtil.matchesRecipe(inventory, inputs, 1, 7);
     }
 
     public ItemStack assemble() {

--- a/common/src/main/java/net/satisfy/meadow/core/recipes/CookingCauldronRecipe.java
+++ b/common/src/main/java/net/satisfy/meadow/core/recipes/CookingCauldronRecipe.java
@@ -33,7 +33,7 @@ public class CookingCauldronRecipe implements Recipe<Container> {
 
     @Override
     public boolean matches(Container inventory, Level world) {
-        return GeneralUtil.matchesRecipe(inventory, inputs, 0, 6);
+        return GeneralUtil.matchesRecipe(inventory, inputs, 1, 6);
     }
 
     public ItemStack assemble() {

--- a/common/src/main/java/net/satisfy/meadow/core/util/GeneralUtil.java
+++ b/common/src/main/java/net/satisfy/meadow/core/util/GeneralUtil.java
@@ -59,7 +59,7 @@ public class GeneralUtil {
 
     public static boolean matchesRecipe(Container inventory, NonNullList<Ingredient> recipe, int startIndex, int endIndex) {
         List<ItemStack> inputStacks = new ArrayList<>();
-        for (int i = startIndex; i <= endIndex; i++) {
+        for (int i = startIndex; i < endIndex; i++) {
             ItemStack stack = inventory.getItem(i);
             if (!stack.isEmpty()) inputStacks.add(stack.copy());
         }


### PR DESCRIPTION
Cooking pot didn't work when result item is present. This is caused by the fact that 1st slot is actually an output slot and should not be checked in recipes